### PR TITLE
メッセージ入力部をform_forで記述し直した

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -160,29 +160,35 @@ html, body {
       position: absolute;
       bottom: 0;
       &__input {
-        width: calc(100% - 100px);
+        width: calc(100% - 150px);
         height: 50px;
         background-color: $mainWhite;
         padding-left: 10px;
         float: left;
         border: none;
       }
-      i {
-        display: block;
-        height: 50px;
-        line-height: 50px;
-        background-color: $mainWhite;
-        color: mainBlack;
-        float: right;
-        padding: 0 15px;
-        margin-right: 10px;
-        border: none;
+      &__pic{
+        i {
+          display: block;
+          height: 50px;
+          line-height: 50px;
+          background-color: $mainWhite;
+          color: mainBlack;
+          float: left;
+          padding: 0 15px;
+          border: none;
+        }
+        #message_hidden{
+          display: none;
+        }
       }
-      &__button {
+      &__send {
         height: 50px;
         width: 100px;
         background-color: $mainBlue;
-        float: right;
+        float: left;
+        color: $mainWhite;
+        border-style: none;
         span {
           display: inline-block;
           width: 100%;

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,10 +15,9 @@
       - for i in 1..10
         = render partial: "message-zone__message"
     .send-message-zone
-      .send-message-zone__input
-        = form_for [@group, @message] do |f|
-          %input.send-message-zone__input{placeholder: "type a message", type: "text"}
-          = link_to "#" do
-            %i.fa.fa-photo
-      %a.send-message-zone__button{href: "#"}
-        %span Send
+      = form_for [@group, @message] do |f|
+        = f.text_field :content, class: 'send-message-zone__input', placeholder: 'type a message'
+        = f.label :image, class: 'send-message-zone__pic' do
+          = fa_icon 'picture-o'
+          = f.file_field 'hidden'
+        = f.submit 'Send', class: 'send-message-zone__send'


### PR DESCRIPTION
・send-message-zone__inputクラスの下にまたsend-message-zone__inputクラスが存在したのでそれを削除
した。
・「入力部「アイコン」「Send」」→「入力部」「アイコン」「Send」にした
・「入力部」「アイコン」「Send」を全てfloat:leftに変更した